### PR TITLE
chore: redeployment on plume testnet

### DIFF
--- a/deployments/SuperUSDPlumeTestnetDeployment.json
+++ b/deployments/SuperUSDPlumeTestnetDeployment.json
@@ -1,0 +1,41 @@
+{
+  "DepositAssets": {
+    "pUSD": {
+      "isPeggedToBase": true,
+      "rateProvider": "0x0000000000000000000000000000000000000000"
+    }
+  },
+  "WithdrawAssets": {
+    "pUSD": {
+      "CompletionWindow": 604800,
+      "MaxLoss": 100,
+      "WithdrawDelay": 180,
+      "WithdrawFee": 0
+    }
+  },
+  "accountantConfiguration": {
+    "AllowedExchangeRateChangeLower": 9950,
+    "AllowedExchangeRateChangeUpper": 10050,
+    "Base": "pUSD",
+    "BaseAddress": "0x1E0E030AbCb4f07de629DCCEa458a271e0E82624",
+    "ManagementFee": 0,
+    "MinimumUpateDelayInSeconds": 21600,
+    "PayoutAddress": "0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4",
+    "StartingExchangeRate": 1000000
+  },
+  "core": {
+    "AccountantWithRateProviders2": "0x67Bc6036c34d244F0C4dDEDf697FD550C96147Cc",
+    "BoringVault": "0x1C6DfA6C99d83aE8b872C32119575ce24407767C",
+    "DecoderAndSanitizer": "0xe60A3D420C3C2d024e98Adc902b3fb1337F1FDB7",
+    "DelayedWithdraw": "0xB5ba16a8354FEd75B81318CBE9B4Ea5787820CDB",
+    "Lens": "0x7a935be5Aa25aE8A6961C500A14A078f7101A4E6",
+    "ManagerWithMerkleVerification": "0x9B7063A1a07Fec4e776ea139000239f5fC7Eab80",
+    "RolesAuthority": "0x9EcC12a700F4C971d69202b244fEbF30B947ecA5",
+    "TellerWithMultiAssetSupport": "0x7CCd743d49f80dcA1c04667C2D7d0524f1244901"
+  },
+  "depositConfiguration": {
+    "AllowPublicDeposits": true,
+    "AllowPublicWithdraws": true,
+    "ShareLockPeriod": 0
+  }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,7 @@ optimism = "${OPTIMISM_RPC_URL}"
 base = "${BASE_RPC_URL}"
 sepolia = "${SEPOLIA_RPC_URL}"
 katanabokuto = "${KATANA_BOKUTO_RPC_URL}"
+plume = "${PLUME_RPC_URL}"
 
 [etherscan]
 # mainnet = { key = "${ETHERSCAN_KEY}", url = "https://api.etherscan.io/api" }
@@ -27,7 +28,7 @@ katanabokuto = "${KATANA_BOKUTO_RPC_URL}"
 # arbitrum = { key = "${ARBISCAN_KEY}" }
 # optimism = { key = "${OPTIMISMSCAN_KEY}" }
 # base = { key = "${BASESCAN_KEY}" }
-#sepolia = { key = "${SEPOLIA_KEY}", chain = 11155111, url = "https://api.etherscan.io/v2/api" }
+# sepolia = { key = "${SEPOLIA_KEY}", chain = 11155111, url = "https://api.etherscan.io/v2/api" }
 sepolia = { key = "${SEPOLIA_KEY}", chain = 11155111, url = "https://api.etherscan.io/v2/api?chainid=11155111" }
 katanabokuto = { key = "${KATANA_BOKUTO_KEY}", chain = 737373, url = "https://explorer-bokuto.katanarpc.com/api" }
 

--- a/script/ArchitectureDeployments/DeployArcticArchitecture.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitecture.sol
@@ -119,6 +119,7 @@ contract DeployArcticArchitecture is Script, ContractNames {
     string depositConfigurationOutput;
 
     struct DeployParams {
+        address previousBoringVault;
         string deploymentFileName;
         address owner;
         string boringVaultName;
@@ -169,42 +170,46 @@ contract DeployArcticArchitecture is Script, ContractNames {
                 lens = ArcticArchitectureLens(deployedAddress);
             }
 
-            deployedAddress = _getAddressIfDeployed(names.boringVault);
-            // boringVault = BoringVault(payable(previoussSuperUSDVault));
-            if (deployedAddress == address(0)) {
-                address implementation = deployer.deployContract(
-                    string.concat(names.boringVault, "-Implementation"),
-                    type(BoringVault).creationCode,
-                    hex"",
-                    0
-                );
-
-                // Prepare initializer data for UUPS proxy
-                bytes memory initializer = abi.encodeWithSelector(
-                    BoringVault.initialize.selector,
-                    params.owner,
-                    rolesAuthority,
-                    params.boringVaultName,
-                    params.boringVaultSymbol,
-                    params.boringVaultDecimals
-                );
-
-                // Deploy the proxy
-                bytes memory proxyCreationCode = abi.encodePacked(
-                    type(ERC1967Proxy).creationCode,
-                    abi.encode(implementation, initializer)
-                );
-
-                address proxy = deployer.deployContract(
-                    names.boringVault,
-                    proxyCreationCode,
-                    hex"",
-                    0
-                );
-
-                boringVault = BoringVault(payable(proxy));
+            if (params.previousBoringVault != address(0)) {
+                boringVault = BoringVault(payable(params.previousBoringVault));
             } else {
-                boringVault = BoringVault(payable(deployedAddress));
+                deployedAddress = _getAddressIfDeployed(names.boringVault);
+                // boringVault = BoringVault(payable(previoussSuperUSDVault));
+                if (deployedAddress == address(0)) {
+                    address implementation = deployer.deployContract(
+                        string.concat(names.boringVault, "-Implementation"),
+                        type(BoringVault).creationCode,
+                        hex"",
+                        0
+                    );
+
+                    // Prepare initializer data for UUPS proxy
+                    bytes memory initializer = abi.encodeWithSelector(
+                        BoringVault.initialize.selector,
+                        params.owner,
+                        rolesAuthority,
+                        params.boringVaultName,
+                        params.boringVaultSymbol,
+                        params.boringVaultDecimals
+                    );
+
+                    // Deploy the proxy
+                    bytes memory proxyCreationCode = abi.encodePacked(
+                        type(ERC1967Proxy).creationCode,
+                        abi.encode(implementation, initializer)
+                    );
+
+                    address proxy = deployer.deployContract(
+                        names.boringVault,
+                        proxyCreationCode,
+                        hex"",
+                        0
+                    );
+
+                    boringVault = BoringVault(payable(proxy));
+                } else {
+                    boringVault = BoringVault(payable(deployedAddress));
+                }
             }
 
             deployedAddress = _getAddressIfDeployed(names.manager);
@@ -324,6 +329,12 @@ contract DeployArcticArchitecture is Script, ContractNames {
                     true
                 );
             }
+            rolesAuthority.setRoleCapability(
+                MANAGER_ROLE,
+                address(boringVault),
+                bytes4(abi.encodeWithSignature("upgradeToAndCall(address,bytes)")),
+                true
+            );
             // MINTER_ROLE
             if (!rolesAuthority.doesRoleHaveCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector)) {
                 rolesAuthority.setRoleCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector, true);

--- a/script/ArchitectureDeployments/DeployArcticArchitecture.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitecture.sol
@@ -892,7 +892,7 @@ contract DeployArcticArchitecture is Script, ContractNames {
             boringVault.setMaxTotalSupply(10_000_000 * 1e6);
 
             // Set all RolesAuthorities.
-            if (boringVault.authority() != rolesAuthority) boringVault.setAuthority(rolesAuthority);
+            // if (boringVault.authority() != rolesAuthority) boringVault.setAuthority(rolesAuthority);
             if (manager.authority() != rolesAuthority) manager.setAuthority(rolesAuthority);
             if (accountant.authority() != rolesAuthority) accountant.setAuthority(rolesAuthority);
             if (teller.authority() != rolesAuthority) teller.setAuthority(rolesAuthority);

--- a/script/ArchitectureDeployments/DeployArcticArchitecture2.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitecture2.sol
@@ -904,7 +904,7 @@ contract DeployArcticArchitecture2 is Script, ContractNames {
             boringVault.setMaxTotalSupply(10_000_000 * 1e6);
 
             // Set all RolesAuthorities.
-            if (boringVault.authority() != rolesAuthority) boringVault.setAuthority(rolesAuthority);
+            // if (boringVault.authority() != rolesAuthority) boringVault.setAuthority(rolesAuthority);
             if (manager.authority() != rolesAuthority) manager.setAuthority(rolesAuthority);
             if (accountant.authority() != rolesAuthority) accountant.setAuthority(rolesAuthority);
             if (teller.authority() != rolesAuthority) teller.setAuthority(rolesAuthority);

--- a/script/ArchitectureDeployments/DeployArcticArchitecture2.sol
+++ b/script/ArchitectureDeployments/DeployArcticArchitecture2.sol
@@ -120,6 +120,7 @@ contract DeployArcticArchitecture2 is Script, ContractNames {
     string depositConfigurationOutput;
 
     struct DeployParams {
+        address previousBoringVault;
         string deploymentFileName;
         address owner;
         string boringVaultName;
@@ -173,42 +174,45 @@ contract DeployArcticArchitecture2 is Script, ContractNames {
             } else {
                 lens = ArcticArchitectureLens(deployedAddress);
             }
-
-            deployedAddress = _getAddressIfDeployed(names.boringVault);
-            if (deployedAddress == address(0)) {
-                address implementation = deployer.deployContract(
-                    string.concat(names.boringVault, "-Implementation"),
-                    type(BoringVault).creationCode,
-                    hex"",
-                    0
-                );
-
-                // Prepare initializer data for UUPS proxy
-                bytes memory initializer = abi.encodeWithSelector(
-                    BoringVault.initialize.selector,
-                    params.owner,
-                    rolesAuthority,
-                    params.boringVaultName,
-                    params.boringVaultSymbol,
-                    params.boringVaultDecimals
-                );
-
-                // Deploy the proxy
-                bytes memory proxyCreationCode = abi.encodePacked(
-                    type(ERC1967Proxy).creationCode,
-                    abi.encode(implementation, initializer)
-                );
-
-                address proxy = deployer.deployContract(
-                    names.boringVault,
-                    proxyCreationCode,
-                    hex"",
-                    0
-                );
-
-                boringVault = BoringVault(payable(proxy));
+            if (params.previousBoringVault != address(0)) {
+                boringVault = BoringVault(payable(params.previousBoringVault));
             } else {
-                boringVault = BoringVault(payable(deployedAddress));
+                deployedAddress = _getAddressIfDeployed(names.boringVault);
+                if (deployedAddress == address(0)) {
+                    address implementation = deployer.deployContract(
+                        string.concat(names.boringVault, "-Implementation"),
+                        type(BoringVault).creationCode,
+                        hex"",
+                        0
+                    );
+
+                    // Prepare initializer data for UUPS proxy
+                    bytes memory initializer = abi.encodeWithSelector(
+                        BoringVault.initialize.selector,
+                        params.owner,
+                        rolesAuthority,
+                        params.boringVaultName,
+                        params.boringVaultSymbol,
+                        params.boringVaultDecimals
+                    );
+
+                    // Deploy the proxy
+                    bytes memory proxyCreationCode = abi.encodePacked(
+                        type(ERC1967Proxy).creationCode,
+                        abi.encode(implementation, initializer)
+                    );
+
+                    address proxy = deployer.deployContract(
+                        names.boringVault,
+                        proxyCreationCode,
+                        hex"",
+                        0
+                    );
+
+                    boringVault = BoringVault(payable(proxy));
+                } else {
+                    boringVault = BoringVault(payable(deployedAddress));
+                }
             }
 
             deployedAddress = _getAddressIfDeployed(names.manager);
@@ -328,6 +332,12 @@ contract DeployArcticArchitecture2 is Script, ContractNames {
                     true
                 );
             }
+            rolesAuthority.setRoleCapability(
+                MANAGER_ROLE,
+                address(boringVault),
+                bytes4(abi.encodeWithSignature("upgradeToAndCall(address,bytes)")),
+                true
+            );
             // MINTER_ROLE
             if (!rolesAuthority.doesRoleHaveCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector)) {
                 rolesAuthority.setRoleCapability(MINTER_ROLE, address(boringVault), BoringVault.enter.selector, true);

--- a/script/katanabokuto/DeploysUSDAITestVault.s.sol
+++ b/script/katanabokuto/DeploysUSDAITestVault.s.sol
@@ -83,6 +83,7 @@ contract DeployTestVaultScript is DeployArcticArchitecture, KatanaBokutoAddresse
         vm.startBroadcast(privateKey);
 
         _deploy(DeployParams({
+            previousBoringVault: address(0),
             deploymentFileName: "sSuperUSDKatanaBokutoDeployment.json",
             owner: owner,
             boringVaultName: boringVaultName,

--- a/script/plumeTestnet/DeployAtomicQueue.s.sol
+++ b/script/plumeTestnet/DeployAtomicQueue.s.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {AtomicQueue} from "src/atomic-queue/AtomicQueue.sol";
+import {AtomicSolverV4} from "src/atomic-queue/AtomicSolverV4.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {PlumeTestnetAddresses} from "test/resources/PlumeTestnetAddresses.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/StdJson.sol";
+
+/**
+ *  source .env && forge script script/DeployAtomicQueue.s.sol:DeployAtomicQueueScript --with-gas-price 70000000 --evm-version london --broadcast --etherscan-api-key $OPTIMISMSCAN_KEY --verify
+ * @dev Optionally can change `--with-gas-price` to something more reasonable
+ */
+contract DeployAtomicQueueScript is Script, ContractNames, PlumeTestnetAddresses {
+    uint256 public privateKey;
+
+    address public devOwner = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+    address public canSolve = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+    address public admin = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+    address public globalOwner = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+
+    // Contracts to deploy
+    Deployer public deployer = Deployer(deployerAddress);
+    RolesAuthority public rolesAuthority;
+    AtomicQueue public atomicQueue;
+    AtomicSolverV4 public atomicSolver;
+    address public owner = dev1Address;
+
+    // Roles
+    uint8 public constant CAN_SOLVE_ROLE = 31;
+    uint8 public constant ONLY_QUEUE_ROLE = 32;
+    uint8 public constant ADMIN_ROLE = 33;
+    uint8 public constant INSTANT_WITHDRAW_ROLE = 34;
+
+    function setUp() external {
+        privateKey = vm.envUint("PRIVATE_KEY");
+        vm.createSelectFork("plume");
+    }
+
+    function run() external {
+        bytes memory creationCode;
+        bytes memory constructorArgs;
+        vm.startBroadcast(privateKey);
+
+        address deployedAddress = _getAddressIfDeployed(UsdaiBoringOnChainQueuesRolesAuthorityName);
+        if (deployedAddress == address(0)) {
+            creationCode = type(RolesAuthority).creationCode;
+            constructorArgs = abi.encode(owner, Authority(address(0)));
+            rolesAuthority =
+                RolesAuthority(deployer.deployContract(UsdaiBoringOnChainQueuesRolesAuthorityName, creationCode, constructorArgs, 0));
+        } else {
+            rolesAuthority = RolesAuthority(deployer.getAddress(UsdaiBoringOnChainQueuesRolesAuthorityName));
+        }
+        creationCode = type(AtomicSolverV4).creationCode;
+        constructorArgs = abi.encode(owner, rolesAuthority);
+        atomicSolver = AtomicSolverV4(deployer.deployContract(UsdaiVaultQueueSolverName, creationCode, constructorArgs, 0));
+
+        creationCode = type(AtomicQueue).creationCode;
+        address accountant = _getAddressIfDeployed(UsdaiVaultAccountantName);
+        constructorArgs = abi.encode(owner, rolesAuthority, accountant, address(atomicSolver));
+        atomicQueue = AtomicQueue(deployer.deployContract(UsdaiVaultQueueName, creationCode, constructorArgs, 0));
+
+        // set RolesAuthority
+        rolesAuthority.setUserRole(canSolve, CAN_SOLVE_ROLE, true);
+        rolesAuthority.setUserRole(admin, ADMIN_ROLE, true);
+        rolesAuthority.transferOwnership(globalOwner);
+        
+        // Give Queue the OnlyQueue role.
+        rolesAuthority.setUserRole(address(atomicQueue), ONLY_QUEUE_ROLE, true);
+        rolesAuthority.setUserRole(address(atomicSolver), CAN_SOLVE_ROLE, true);
+
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.setMaturityTime.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.setDiscount.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.addToWhitelist.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.removeFromWhitelist.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.updateWhitelistMaturityDivisor.selector, true);
+        rolesAuthority.setRoleCapability(INSTANT_WITHDRAW_ROLE, address(atomicQueue), AtomicQueue.instantWithdraw.selector, true);
+        rolesAuthority.setRoleCapability(ADMIN_ROLE, address(atomicQueue), AtomicQueue.setSolver.selector, true);
+        rolesAuthority.setRoleCapability(ADMIN_ROLE, address(atomicQueue), AtomicQueue.cancelAtomicRequestByAdmin.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicSolver), AtomicSolverV4.finishSolve.selector, true);
+        rolesAuthority.setRoleCapability(ADMIN_ROLE, address(atomicSolver), AtomicSolverV4.rescueTokens.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicSolver), AtomicSolverV4.approveOfferForQueue.selector, true);
+        rolesAuthority.setPublicCapability(address(atomicQueue), AtomicQueue.updateAtomicRequest.selector, true);
+        rolesAuthority.setPublicCapability(address(atomicQueue), AtomicQueue.cancelAtomicRequest.selector, true);
+        rolesAuthority.setPublicCapability(address(atomicSolver), AtomicSolverV4.redeemSolve.selector, true);
+
+        // extra setting
+        atomicQueue.setMaturityTime(3 minutes);
+
+        // extra role setting for other contracts
+        RolesAuthority vaultRolesAuthority = RolesAuthority(deployer.getAddress(UsdaiVaultRolesAuthorityName));
+        vaultRolesAuthority.setUserRole(address(atomicSolver), 12, true); // 12: solver role
+        vaultRolesAuthority.setUserRole(address(atomicQueue), 12, true); // 12: solver role
+        vaultRolesAuthority.setUserRole(deployer.getAddress(UsdaiVaultTellerName), 3, true); // 3: buy role
+        vaultRolesAuthority.setUserRole(deployer.getAddress(UsdaiLayerZeroTellerName), 3, true); // 3: buy role
+        vaultRolesAuthority.setUserRole(deployer.getAddress(UsdaiChainlinkCCIPTellerName), 3, true); // 3: buy role
+        vm.stopBroadcast();
+    }
+
+    function _getAddressIfDeployed(string memory name) internal view returns (address) {
+        address deployedAt = deployer.getAddress(name);
+        uint256 size;
+        assembly {
+            size := extcodesize(deployedAt)
+        }
+        return size > 0 ? deployedAt : address(0);
+    }
+}

--- a/script/plumeTestnet/DeployDeployer.s.sol
+++ b/script/plumeTestnet/DeployDeployer.s.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import {Deployer} from "src/helper/Deployer.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {PlumeTestnetAddresses} from "test/resources/PlumeTestnetAddresses.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/StdJson.sol";
+
+/**
+ *  source .env && forge script script/DeployDeployer.s.sol:DeployDeployerScript --with-gas-price 30000000000 --slow --broadcast --etherscan-api-key $ETHERSCAN_KEY --verify
+ * @dev Optionally can change `--with-gas-price` to something more reasonable
+ */
+contract DeployDeployerScript is Script, ContractNames, PlumeTestnetAddresses {
+    uint256 public privateKey;
+
+    // Contracts to deploy
+    RolesAuthority public rolesAuthority;
+    Deployer public deployer;
+
+    uint8 public DEPLOYER_ROLE = 1;
+
+    function setUp() external {
+        privateKey = vm.envUint("PRIVATE_KEY");
+        vm.createSelectFork("plume");
+    }
+
+    function run() external {
+        bytes memory creationCode;
+        bytes memory constructorArgs;
+        bytes32 DEPLOYER_SALT = keccak256(abi.encode(UsdaiDeployerName));
+ 
+        vm.startBroadcast(privateKey);
+
+        creationCode = type(Deployer).creationCode;
+        constructorArgs = abi.encode(dev0Address, Authority(address(0)));
+        bytes memory initCode = abi.encodePacked(creationCode, constructorArgs);
+        
+        address predictedAddress = computeCreate2Address(DEPLOYER_SALT, keccak256(initCode));
+        console.log("Deployer will be deployed at:", predictedAddress);
+        
+        address deployerAddress = deployWithCreate2(initCode, DEPLOYER_SALT);
+        
+        require(deployerAddress != address(0), "CREATE2 deployment failed");
+        console.log("Deployer successfully deployed at:", deployerAddress);
+
+        deployer = Deployer(deployerAddress);
+        creationCode = type(RolesAuthority).creationCode;
+        constructorArgs = abi.encode(dev0Address, Authority(address(0)));
+        rolesAuthority =
+            RolesAuthority(deployer.deployContract(UsdaiVaultRolesAuthorityName, creationCode, constructorArgs, 0));
+
+        deployer.setAuthority(rolesAuthority);
+
+        rolesAuthority.setRoleCapability(DEPLOYER_ROLE, address(deployer), Deployer.deployContract.selector, true);
+        rolesAuthority.setUserRole(dev0Address, DEPLOYER_ROLE, true);
+        rolesAuthority.setUserRole(dev1Address, DEPLOYER_ROLE, true);
+
+        vm.stopBroadcast();
+    }
+
+    function deployWithCreate2(bytes memory initCode, bytes32 salt) internal returns (address deployedAddress) {
+        assembly {
+            deployedAddress := create2(0, add(initCode, 0x20), mload(initCode), salt)
+            if iszero(deployedAddress) {
+                revert(0, 0)
+            }
+        }
+    }
+}

--- a/script/plumeTestnet/DeployTestVault.s.sol
+++ b/script/plumeTestnet/DeployTestVault.s.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import {DeployArcticArchitecture2, ERC20, Deployer} from "script/ArchitectureDeployments/DeployArcticArchitecture2.sol";
 import {AddressToBytes32Lib} from "src/helper/AddressToBytes32Lib.sol";
-import {KatanaBokutoAddresses} from "test/resources/KatanaBokutoAddresses.sol";
+import {PlumeTestnetAddresses} from "test/resources/PlumeTestnetAddresses.sol";
 
 // Import Decoder and Sanitizer to deploy.
 import {ITBPositionDecoderAndSanitizer} from
@@ -13,7 +13,7 @@ import {ITBPositionDecoderAndSanitizer} from
  *  source .env && forge script script/ArchitectureDeployments/DeployTestVault.s.sol:DeployTestVaultScript --with-gas-price 30000000000 --slow --broadcast --etherscan-api-key $ETHERSCAN_KEY --verify
  * @dev Optionally can change `--with-gas-price` to something more reasonable
  */
-contract DeployTestVaultScript is DeployArcticArchitecture2, KatanaBokutoAddresses {
+contract DeployTestVaultScript is DeployArcticArchitecture2, PlumeTestnetAddresses {
     using AddressToBytes32Lib for address;
 
     uint256 public privateKey;
@@ -26,7 +26,7 @@ contract DeployTestVaultScript is DeployArcticArchitecture2, KatanaBokutoAddress
 
     function setUp() external {
         privateKey = vm.envUint("PRIVATE_KEY");
-        vm.createSelectFork("katanabokuto");
+        vm.createSelectFork("plume");
     }
 
     function run() external {
@@ -56,7 +56,7 @@ contract DeployTestVaultScript is DeployArcticArchitecture2, KatanaBokutoAddress
 
         // Define Accountant Parameters.
         accountantParameters.payoutAddress = liquidPayoutAddress;
-        accountantParameters.base = USDC;
+        accountantParameters.base = PUSD;
         // Decimals are in terms of `base`.
         accountantParameters.startingExchangeRate = 1e6;
         //  4 decimals
@@ -89,7 +89,7 @@ contract DeployTestVaultScript is DeployArcticArchitecture2, KatanaBokutoAddress
         // Setup withdraw assets.
         withdrawAssets.push(
             WithdrawAsset({
-                asset: USDC,
+                asset: PUSD,
                 withdrawDelay: 3 minutes,
                 completionWindow: 7 days,
                 withdrawFee: 0,
@@ -109,14 +109,14 @@ contract DeployTestVaultScript is DeployArcticArchitecture2, KatanaBokutoAddress
 
         bool allowPublicDeposits = true;
         bool allowPublicWithdraws = true;
-        uint64 shareLockPeriod = 1;
+        uint64 shareLockPeriod = 0;
         address delayedWithdrawFeeAddress = liquidPayoutAddress;
 
         vm.startBroadcast(privateKey);
 
         _deploy(DeployParams({
-            previousBoringVault: address(0),
-            deploymentFileName: "SuperUSDKatanaBokutoDeployment.json",
+            previousBoringVault: previoussuperUSD,
+            deploymentFileName: "SuperUSDPlumeTestnetDeployment.json",
             owner: owner,
             boringVaultName: boringVaultName,
             boringVaultSymbol: boringVaultSymbol,

--- a/script/plumeTestnet/DeployedUSDAI/CancelRequest.s.sol
+++ b/script/plumeTestnet/DeployedUSDAI/CancelRequest.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+contract USDAICancelRequestScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper {
+    // Contract instances
+    Deployer public deployer;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    ArcticArchitectureLens lens;
+    AccountantWithRateProviders accountant;
+    AtomicQueue queue;
+
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        
+        // Initialize contract instances
+        boringVault = BoringVault(payable(deployer.getAddress(UsdaiVaultName)));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(UsdaiVaultTellerName));
+        lens = ArcticArchitectureLens(deployer.getAddress(UsdaiArcticArchitectureLensName));
+        accountant = AccountantWithRateProviders(deployer.getAddress(UsdaiVaultAccountantName));
+        queue = AtomicQueue(deployer.getAddress(UsdaiVaultQueueName));
+    }
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+
+        vm.startBroadcast(privateKey);
+        
+        (bytes32[] memory requestIds, AtomicRequest[] memory requests) = queue.getExistingWithdrawRequestsByUser(user);
+        queue.cancelAtomicRequest(requests[0]);
+        
+        vm.stopBroadcast();
+    }
+}

--- a/script/plumeTestnet/DeployedUSDAI/Deposit.s.sol
+++ b/script/plumeTestnet/DeployedUSDAI/Deposit.s.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+/**
+ * @title USDAI Deposit Integration Test
+ * @notice This script demonstrates how to deposit USDC into the USDAI vault on Sepolia
+ * @dev Run with: forge script script/USDAIIntegrationTest/Deposit.sol --rpc-url $MINATO_RPC_URL
+ */
+contract USDAIDepositScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper{
+    // Test parameters
+    uint256 public constant USDC_DEPOSIT_AMOUNT = 2 * 1e6; // 1 USDC (6 decimals)
+    
+    // Contract instances
+    Deployer public deployer;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    ArcticArchitectureLens lens;
+    AccountantWithRateProviders accountant;
+
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        
+        // Initialize contract instances
+        boringVault = BoringVault(payable(deployer.getAddress(UsdaiVaultName)));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(UsdaiVaultTellerName));
+        lens = ArcticArchitectureLens(deployer.getAddress(UsdaiArcticArchitectureLensName));
+        accountant = AccountantWithRateProviders(deployer.getAddress(UsdaiVaultAccountantName));
+    }
+
+    function run() public {
+        // Get the private key from environment variable
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+        
+        // Start broadcasting transactions
+        vm.startBroadcast(privateKey);
+        
+        // Deposit USDC
+        if (USDC.balanceOf(user) >= USDC_DEPOSIT_AMOUNT) {
+            console.log("\n=== Depositing USDC ===");
+
+            USDC.approve(address(boringVault), USDC_DEPOSIT_AMOUNT);
+
+            // // Deposit USDC
+            uint256 sharesBefore = boringVault.balanceOf(user);
+            teller.deposit(USDC, USDC_DEPOSIT_AMOUNT, 0);
+            uint256 sharesAfter = boringVault.balanceOf(user);
+            
+            console.log("Actual shares received:", (sharesAfter - sharesBefore) / 1e6);
+        } else {
+            console.log("Insufficient USDC balance for deposit");
+        }
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/plumeTestnet/DeployedUSDAI/InstantWithdraw.s.sol
+++ b/script/plumeTestnet/DeployedUSDAI/InstantWithdraw.s.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+contract USDAIInstantWithdrawScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper {
+    // Contract instances
+    Deployer public deployer;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    ArcticArchitectureLens lens;
+    AccountantWithRateProviders accountant;
+    AtomicQueue queue;
+
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        
+        // Initialize contract instances
+        boringVault = BoringVault(payable(deployer.getAddress(UsdaiVaultName)));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(UsdaiVaultTellerName));
+        lens = ArcticArchitectureLens(deployer.getAddress(UsdaiArcticArchitectureLensName));
+        accountant = AccountantWithRateProviders(deployer.getAddress(UsdaiVaultAccountantName));
+        queue = AtomicQueue(deployer.getAddress(UsdaiVaultQueueName));
+    }
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+        vm.startBroadcast(privateKey);
+        ERC20(address(boringVault)).approve(address(queue), 1e5);
+        queue.instantWithdraw(ERC20(address(boringVault)), USDC, 1e5, 0, teller);
+        
+        vm.stopBroadcast();
+    }
+}

--- a/script/plumeTestnet/DeployedUSDAI/WithdrawRequest.s.sol
+++ b/script/plumeTestnet/DeployedUSDAI/WithdrawRequest.s.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+contract USDAIWithdrawRequestScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper {
+    // Contract instances
+    Deployer public deployer;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    ArcticArchitectureLens lens;
+    AccountantWithRateProviders accountant;
+    AtomicQueue queue;
+
+    // User's initial share balance
+    uint256 initialShares;
+    uint256 withdrawShares;
+
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        
+        // Initialize contract instances
+        boringVault = BoringVault(payable(deployer.getAddress(UsdaiVaultName)));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(UsdaiVaultTellerName));
+        lens = ArcticArchitectureLens(deployer.getAddress(UsdaiArcticArchitectureLensName));
+        accountant = AccountantWithRateProviders(deployer.getAddress(UsdaiVaultAccountantName));
+        queue = AtomicQueue(deployer.getAddress(UsdaiVaultQueueName));
+    }
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+        
+        initialShares = boringVault.balanceOf(user);
+        
+        withdrawShares = 1 * 1e5;
+        vm.startBroadcast(privateKey);
+
+        // Check if user has shares to withdraw
+        if (initialShares >= withdrawShares) {
+            console.log("\n=== Requesting Withdrawal via Queue ===");
+            console.log("Requesting withdrawal of shares amount:", withdrawShares / 1e6, "shares");
+            
+            // Approve queue to spend shares
+            boringVault.approve(address(queue), withdrawShares);
+
+            // Create atomic request
+            AtomicRequest memory request = AtomicRequest({
+                deadline: uint64(block.timestamp + 10000 minutes), 
+                creationTime: uint64(block.timestamp),
+                offerAmount: uint96(withdrawShares),
+                user: user,
+                offer: address(boringVault),
+                want: address(USDC)
+            });
+
+            // Send request to queue
+            queue.updateAtomicRequest(request);
+
+            console.log("Withdrawal request created");
+
+            // Get the request IDs and display the first one
+            // bytes32[] memory requestIds = queue.getUserAtomicRequestIds(user, boringVault, USDC);
+            // if (requestIds.length > 0) {
+            //     console.log("Request ID:", uint256(requestIds[0]));
+                
+            //     // Decode request information from ID
+            //     (,,,uint64 deadline, uint88 atomicPrice, uint96 offerAmount) = 
+            //         abi.decode(requestIds[0], (address, address, address, uint64, uint88, uint96));
+                
+            //     console.log("Request details:");
+            //     console.log("- Deadline:", deadline);
+            //     console.log("- Atomic Price:", atomicPrice);
+            //     console.log("- Offer Amount:", offerAmount);
+            // }
+        } else {
+            console.log("No shares available for withdrawal");
+        }
+        
+        vm.stopBroadcast();
+    }
+}

--- a/script/plumeTestnet/DeployedUSDAI/WithdrawRequestSolve.s.sol
+++ b/script/plumeTestnet/DeployedUSDAI/WithdrawRequestSolve.s.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {AtomicSolverV4} from "src/atomic-queue/AtomicSolverV4.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+import {console} from "forge-std/console.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+
+contract SolveWithdrawRequestScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper {
+    // Contract instances
+    Deployer public deployer;
+    AtomicQueue queue;
+    AtomicSolverV4 solver;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        
+        // Initialize contract instances
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        boringVault = BoringVault(payable(deployer.getAddress(UsdaiVaultName)));
+        queue = AtomicQueue(deployer.getAddress(UsdaiVaultQueueName));
+        solver = AtomicSolverV4(deployer.getAddress(UsdaiVaultQueueSolverName));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(UsdaiVaultTellerName));
+    }
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+        
+        vm.startBroadcast(privateKey);
+        
+        // Get user's request IDs
+        (bytes32[] memory requestIds, AtomicRequest[] memory requests) = queue.getExistingWithdrawRequestsByUser(user);
+        require(requestIds.length > 0, "No requests found");
+
+        // Call redeemSolve
+        solver.redeemSolve(
+            queue,
+            0,
+            type(uint256).max,
+            teller,
+            requests[0]
+        );
+        
+        vm.stopBroadcast();
+        
+        // console.log("=== Solve Complete ===");
+        // console.log("User:", user);
+        // console.log("Shares Solved:", offerAmount);
+        // console.log("Assets Required:", assetsRequired);
+        // console.log("Request Deadline:", deadline);
+        // console.log("Atomic Price:", atomicPrice);
+    }
+}

--- a/script/plumeTestnet/DeployedsUSDAI/CancelRequest.s.sol
+++ b/script/plumeTestnet/DeployedsUSDAI/CancelRequest.s.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+contract sUSDAICancelRequestScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper {
+    // Contract instances
+    Deployer public deployer;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    ArcticArchitectureLens lens;
+    AccountantWithRateProviders accountant;
+    AtomicQueue queue;
+
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        
+        // Initialize contract instances
+        boringVault = BoringVault(payable(deployer.getAddress(sUsdaiVaultName)));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(sUsdaiVaultTellerName));
+        lens = ArcticArchitectureLens(deployer.getAddress(sUsdaiArcticArchitectureLensName));
+        accountant = AccountantWithRateProviders(deployer.getAddress(sUsdaiVaultAccountantName));
+        queue = AtomicQueue(deployer.getAddress(sUsdaiVaultQueueName));
+    }
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+
+        vm.startBroadcast(privateKey);
+        
+        (bytes32[] memory requestIds, AtomicRequest[] memory requests) = queue.getExistingWithdrawRequestsByUser(user);
+        queue.cancelAtomicRequest(requests[0]);
+        
+        vm.stopBroadcast();
+    }
+}

--- a/script/plumeTestnet/DeployedsUSDAI/Deposit.s.sol
+++ b/script/plumeTestnet/DeployedsUSDAI/Deposit.s.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+/**
+ * @title USDAI Deposit Integration Test
+ * @notice This script demonstrates how to deposit USDC into the USDAI vault on Sepolia
+ * @dev Run with: forge script script/USDAIIntegrationTest/Deposit.sol --rpc-url $MINATO_RPC_URL
+ */
+contract sUSDAIDepositScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper{
+    // Test parameters
+    uint256 public constant USDAI_DEPOSIT_AMOUNT = 2 * 1e5; // 1 USDAI (6 decimals)
+    
+    // Contract instances
+    Deployer public deployer;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    ArcticArchitectureLens lens;
+    AccountantWithRateProviders accountant;
+
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        
+        // Initialize contract instances
+        boringVault = BoringVault(payable(deployer.getAddress(sUsdaiVaultName)));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(sUsdaiVaultTellerName));
+        lens = ArcticArchitectureLens(deployer.getAddress(sUsdaiArcticArchitectureLensName));
+        accountant = AccountantWithRateProviders(deployer.getAddress(sUsdaiVaultAccountantName));
+    }
+
+    function run() public {
+        // Get the private key from environment variable
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+        
+        // Start broadcasting transactions
+        vm.startBroadcast(privateKey);
+        
+        // Deposit USDC
+        if (USDAI.balanceOf(user) >= USDAI_DEPOSIT_AMOUNT) {
+            console.log("\n=== Depositing USDAI ===");
+
+            USDAI.approve(address(boringVault), USDAI_DEPOSIT_AMOUNT);
+
+            // // Deposit USDAI
+            uint256 sharesBefore = boringVault.balanceOf(user);
+            teller.deposit(USDAI, USDAI_DEPOSIT_AMOUNT, 0);
+            uint256 sharesAfter = boringVault.balanceOf(user);
+            
+            console.log("Actual shares received:", (sharesAfter - sharesBefore) / 1e6);
+        } else {
+            console.log("Insufficient USDAI balance for deposit");
+        }
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/plumeTestnet/DeployedsUSDAI/InstantWithdraw.s.sol
+++ b/script/plumeTestnet/DeployedsUSDAI/InstantWithdraw.s.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+contract sUSDAIInstantWithdrawScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper {
+    // Contract instances
+    Deployer public deployer;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    ArcticArchitectureLens lens;
+    AccountantWithRateProviders accountant;
+    AtomicQueue queue;
+
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        
+        // Initialize contract instances
+        boringVault = BoringVault(payable(deployer.getAddress(sUsdaiVaultName)));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(sUsdaiVaultTellerName));
+        lens = ArcticArchitectureLens(deployer.getAddress(sUsdaiArcticArchitectureLensName));
+        accountant = AccountantWithRateProviders(deployer.getAddress(sUsdaiVaultAccountantName));
+        queue = AtomicQueue(deployer.getAddress(sUsdaiVaultQueueName));
+    }
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+        vm.startBroadcast(privateKey);
+        ERC20(address(boringVault)).approve(address(queue), 1e5);
+        queue.instantWithdraw(ERC20(address(boringVault)), USDAI, 1e5, 0, teller);
+        
+        vm.stopBroadcast();
+    }
+}

--- a/script/plumeTestnet/DeployedsUSDAI/WithdrawRequest.s.sol
+++ b/script/plumeTestnet/DeployedsUSDAI/WithdrawRequest.s.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {ArcticArchitectureLens} from "src/helper/ArcticArchitectureLens.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+
+contract sUSDAIWithdrawRequestScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper {
+    // Contract instances
+    Deployer public deployer;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    ArcticArchitectureLens lens;
+    AccountantWithRateProviders accountant;
+    AtomicQueue queue;
+
+    // User's initial share balance
+    uint256 initialShares;
+    uint256 withdrawShares;
+
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        
+        // Initialize contract instances
+        boringVault = BoringVault(payable(deployer.getAddress(sUsdaiVaultName)));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(sUsdaiVaultTellerName));
+        lens = ArcticArchitectureLens(deployer.getAddress(sUsdaiArcticArchitectureLensName));
+        accountant = AccountantWithRateProviders(deployer.getAddress(sUsdaiVaultAccountantName));
+        queue = AtomicQueue(deployer.getAddress(sUsdaiVaultQueueName));
+    }
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+        
+        initialShares = boringVault.balanceOf(user);
+        
+        withdrawShares = 1 * 1e5;
+        vm.startBroadcast(privateKey);
+
+        // Check if user has shares to withdraw
+        if (initialShares >= withdrawShares) {
+            console.log("\n=== Requesting Withdrawal via Queue ===");
+            console.log("Requesting withdrawal of shares amount:", withdrawShares / 1e6, "shares");
+            
+            // Approve queue to spend shares
+            boringVault.approve(address(queue), withdrawShares);
+
+            // Create atomic request
+            AtomicRequest memory request = AtomicRequest({
+                deadline: uint64(block.timestamp + 10000 minutes), 
+                creationTime: uint64(block.timestamp),
+                offerAmount: uint96(withdrawShares),
+                user: user,
+                offer: address(boringVault),
+                want: address(USDAI)
+            });
+
+            // Send request to queue
+            queue.updateAtomicRequest(request);
+
+            console.log("Withdrawal request created");
+
+            // Get the request IDs and display the first one
+            // bytes32[] memory requestIds = queue.getUserAtomicRequestIds(user, boringVault, USDC);
+            // if (requestIds.length > 0) {
+            //     console.log("Request ID:", uint256(requestIds[0]));
+                
+            //     // Decode request information from ID
+            //     (,,,uint64 deadline, uint88 atomicPrice, uint96 offerAmount) = 
+            //         abi.decode(requestIds[0], (address, address, address, uint64, uint88, uint96));
+                
+            //     console.log("Request details:");
+            //     console.log("- Deadline:", deadline);
+            //     console.log("- Atomic Price:", atomicPrice);
+            //     console.log("- Offer Amount:", offerAmount);
+            // }
+        } else {
+            console.log("No shares available for withdrawal");
+        }
+        
+        vm.stopBroadcast();
+    }
+}

--- a/script/plumeTestnet/DeployedsUSDAI/WithdrawRequestSolve.s.sol
+++ b/script/plumeTestnet/DeployedsUSDAI/WithdrawRequestSolve.s.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import "forge-std/Script.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {AtomicSolverV4} from "src/atomic-queue/AtomicSolverV4.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+import {console} from "forge-std/console.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+
+contract SolveWithdrawRequestScript is Script, SepoliaAddresses, ContractNames, MerkleTreeHelper {
+    // Contract instances
+    Deployer public deployer;
+    AtomicQueue queue;
+    AtomicSolverV4 solver;
+    BoringVault boringVault;
+    TellerWithMultiAssetSupport teller;
+    
+    function setUp() public {
+        vm.createSelectFork("sepolia");
+        setSourceChainName("sepolia");
+        
+        // Initialize contract instances
+        deployer = Deployer(getAddress(sourceChain, "deployerAddress"));
+        boringVault = BoringVault(payable(deployer.getAddress(sUsdaiVaultName)));
+        queue = AtomicQueue(deployer.getAddress(sUsdaiVaultQueueName));
+        solver = AtomicSolverV4(deployer.getAddress(sUsdaiVaultQueueSolverName));
+        teller = TellerWithMultiAssetSupport(deployer.getAddress(sUsdaiVaultTellerName));
+    }
+
+    function run() public {
+        uint256 privateKey = vm.envUint("PRIVATE_KEY");
+        address user = vm.addr(privateKey);
+        
+        vm.startBroadcast(privateKey);
+        
+        // Get user's request IDs
+        (bytes32[] memory requestIds, AtomicRequest[] memory requests) = queue.getExistingWithdrawRequestsByUser(user);
+        require(requestIds.length > 0, "No requests found");
+        
+        // Call redeemSolve
+        solver.redeemSolve(
+            queue,
+            0,
+            type(uint256).max,
+            teller,
+            requests[0]
+        );
+        
+        vm.stopBroadcast();
+        
+        // console.log("=== Solve Complete ===");
+        // console.log("User:", user);
+        // console.log("Shares Solved:", offerAmount);
+        // console.log("Assets Required:", assetsRequired);
+        // console.log("Request Deadline:", deadline);
+        // console.log("Atomic Price:", atomicPrice);
+    }
+}

--- a/script/plumeTestnet/DeploysUSDAIAtomicQueue.s.sol
+++ b/script/plumeTestnet/DeploysUSDAIAtomicQueue.s.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {AtomicQueue} from "src/atomic-queue/AtomicQueue.sol";
+import {AtomicSolverV4} from "src/atomic-queue/AtomicSolverV4.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {SepoliaAddresses} from "test/resources/SepoliaAddresses.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/StdJson.sol";
+
+/**
+ *  source .env && forge script script/DeployAtomicQueue.s.sol:DeployAtomicQueueScript --with-gas-price 70000000 --evm-version london --broadcast --etherscan-api-key $OPTIMISMSCAN_KEY --verify
+ * @dev Optionally can change `--with-gas-price` to something more reasonable
+ */
+contract DeployAtomicQueueScript is Script, ContractNames, SepoliaAddresses {
+    uint256 public privateKey;
+
+    address public devOwner = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+    address public canSolve = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+    address public admin = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+    address public globalOwner = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+
+    // Contracts to deploy
+    Deployer public deployer = Deployer(deployerAddress);
+    RolesAuthority public rolesAuthority;
+    AtomicQueue public atomicQueue;
+    AtomicSolverV4 public atomicSolver;
+    address public owner = dev1Address;
+
+    // Roles
+    uint8 public constant CAN_SOLVE_ROLE = 31;
+    uint8 public constant ONLY_QUEUE_ROLE = 32;
+    uint8 public constant ADMIN_ROLE = 33;
+    uint8 public constant INSTANT_WITHDRAW_ROLE = 34;
+
+    function setUp() external {
+        privateKey = vm.envUint("PRIVATE_KEY");
+        vm.createSelectFork("sepolia");
+    }
+
+    function run() external {
+        bytes memory creationCode;
+        bytes memory constructorArgs;
+        vm.startBroadcast(privateKey);
+
+        address deployedAddress = _getAddressIfDeployed(sUsdaiBoringOnChainQueuesRolesAuthorityName);
+        if (deployedAddress == address(0)) {
+            creationCode = type(RolesAuthority).creationCode;
+            constructorArgs = abi.encode(owner, Authority(address(0)));
+            rolesAuthority =
+                RolesAuthority(deployer.deployContract(sUsdaiBoringOnChainQueuesRolesAuthorityName, creationCode, constructorArgs, 0));
+        } else {
+            rolesAuthority = RolesAuthority(deployer.getAddress(sUsdaiBoringOnChainQueuesRolesAuthorityName));
+        }
+
+        creationCode = type(AtomicSolverV4).creationCode;
+        constructorArgs = abi.encode(owner, rolesAuthority);
+        atomicSolver = AtomicSolverV4(deployer.deployContract(sUsdaiVaultQueueSolverName, creationCode, constructorArgs, 0));
+
+        creationCode = type(AtomicQueue).creationCode;
+        address accountant = _getAddressIfDeployed(sUsdaiVaultAccountantName);
+        constructorArgs = abi.encode(owner, rolesAuthority, accountant, address(atomicSolver));
+        atomicQueue = AtomicQueue(deployer.deployContract(sUsdaiVaultQueueName, creationCode, constructorArgs, 0));
+
+        // set RolesAuthority
+        rolesAuthority.setUserRole(canSolve, CAN_SOLVE_ROLE, true);
+        rolesAuthority.setUserRole(admin, ADMIN_ROLE, true);
+        rolesAuthority.transferOwnership(globalOwner);
+        
+        // Give Queue the OnlyQueue role.
+        rolesAuthority.setUserRole(address(atomicQueue), ONLY_QUEUE_ROLE, true);
+        rolesAuthority.setUserRole(address(atomicSolver), CAN_SOLVE_ROLE, true);
+
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.setMaturityTime.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.setDiscount.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.addToWhitelist.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.removeFromWhitelist.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicQueue), AtomicQueue.updateWhitelistMaturityDivisor.selector, true);
+        // rolesAuthority.setRoleCapability(INSTANT_WITHDRAW_ROLE, address(atomicQueue), AtomicQueue.instantWithdraw.selector, true);
+        rolesAuthority.setRoleCapability(ADMIN_ROLE, address(atomicQueue), AtomicQueue.setSolver.selector, true);
+        rolesAuthority.setRoleCapability(ADMIN_ROLE, address(atomicQueue), AtomicQueue.cancelAtomicRequestByAdmin.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicSolver), AtomicSolverV4.finishSolve.selector, true);
+        rolesAuthority.setRoleCapability(ADMIN_ROLE, address(atomicSolver), AtomicSolverV4.rescueTokens.selector, true);
+        rolesAuthority.setRoleCapability(ONLY_QUEUE_ROLE, address(atomicSolver), AtomicSolverV4.approveOfferForQueue.selector, true);
+        rolesAuthority.setPublicCapability(address(atomicQueue), AtomicQueue.updateAtomicRequest.selector, true);
+        rolesAuthority.setPublicCapability(address(atomicQueue), AtomicQueue.cancelAtomicRequest.selector, true);
+        rolesAuthority.setPublicCapability(address(atomicQueue), AtomicQueue.instantWithdraw.selector, true);
+        rolesAuthority.setPublicCapability(address(atomicSolver), AtomicSolverV4.redeemSolve.selector, true);
+
+        // extra setting
+        atomicQueue.setMaturityTime(3 minutes);
+        atomicQueue.setDiscount(0);
+
+        // extra role setting for other contracts
+        RolesAuthority vaultRolesAuthority = RolesAuthority(deployer.getAddress(sUsdaiVaultRolesAuthorityName));
+        vaultRolesAuthority.setUserRole(address(atomicSolver), 12, true); // 12: solver role
+        vaultRolesAuthority.setUserRole(address(atomicQueue), 12, true); // 12: solver role
+        vaultRolesAuthority.setUserRole(deployer.getAddress(sUsdaiVaultTellerName), 3, true); // 3: buy role
+        vaultRolesAuthority.setUserRole(deployer.getAddress(sUsdaiLayerZeroTellerName), 3, true); // 3: buy role
+        vaultRolesAuthority.setUserRole(deployer.getAddress(sUsdaiChainlinkCCIPTellerName), 3, true); // 3: buy role
+        vm.stopBroadcast();
+    }
+
+    function _getAddressIfDeployed(string memory name) internal view returns (address) {
+        address deployedAt = deployer.getAddress(name);
+        uint256 size;
+        assembly {
+            size := extcodesize(deployedAt)
+        }
+        return size > 0 ? deployedAt : address(0);
+    }
+}

--- a/script/plumeTestnet/DeploysUSDAITestVault.s.sol
+++ b/script/plumeTestnet/DeploysUSDAITestVault.s.sol
@@ -1,44 +1,44 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.21;
 
-import {DeployArcticArchitecture2, ERC20, Deployer} from "script/ArchitectureDeployments/DeployArcticArchitecture2.sol";
+import {DeployArcticArchitecture, ERC20, Deployer} from "script/ArchitectureDeployments/DeployArcticArchitecture.sol";
 import {AddressToBytes32Lib} from "src/helper/AddressToBytes32Lib.sol";
-import {KatanaBokutoAddresses} from "test/resources/KatanaBokutoAddresses.sol";
+import {PlumeTestnetAddresses} from "test/resources/PlumeTestnetAddresses.sol";
 
 // Import Decoder and Sanitizer to deploy.
-import {ITBPositionDecoderAndSanitizer} from
-    "src/base/DecodersAndSanitizers/Protocols/ITB/ITBPositionDecoderAndSanitizer.sol";
+import {BaseDecoderAndSanitizer} from
+    "src/base/DecodersAndSanitizers/BaseDecoderAndSanitizer.sol";
 
 /**
  *  source .env && forge script script/ArchitectureDeployments/DeployTestVault.s.sol:DeployTestVaultScript --with-gas-price 30000000000 --slow --broadcast --etherscan-api-key $ETHERSCAN_KEY --verify
  * @dev Optionally can change `--with-gas-price` to something more reasonable
  */
-contract DeployTestVaultScript is DeployArcticArchitecture2, KatanaBokutoAddresses {
+contract DeployTestVaultScript is DeployArcticArchitecture, PlumeTestnetAddresses {
     using AddressToBytes32Lib for address;
 
     uint256 public privateKey;
 
     // Deployment parameters
-    string public boringVaultName = "SuperUSD";
-    string public boringVaultSymbol = "SuperUSD";
+    string public boringVaultName = "sSuperUSD";
+    string public boringVaultSymbol = "sSuperUSD";
     uint8 public boringVaultDecimals = 6;
     address public owner = dev0Address;
 
     function setUp() external {
         privateKey = vm.envUint("PRIVATE_KEY");
-        vm.createSelectFork("katanabokuto");
+        vm.createSelectFork("plume");
     }
 
     function run() external {
         // Define names to determine where contracts are deployed.
-        names.rolesAuthority = UsdaiVaultRolesAuthorityName;
-        names.lens = UsdaiArcticArchitectureLensName;
-        names.boringVault = UsdaiVaultName;
-        names.manager = UsdaiVaultManagerName;
-        names.accountant = UsdaiVaultAccountantName;
-        names.teller = UsdaiVaultTellerName;
-        names.rawDataDecoderAndSanitizer = UsdaiVaultDecoderAndSanitizerName;
-        names.delayedWithdrawer = UsdaiVaultDelayedWithdrawer;
+        names.rolesAuthority = sUsdaiVaultRolesAuthorityName;
+        names.lens = sUsdaiArcticArchitectureLensName;
+        names.boringVault = sUsdaiVaultName;
+        names.manager = sUsdaiVaultManagerName;
+        names.accountant = sUsdaiVaultAccountantName;
+        names.teller = sUsdaiVaultTellerName;
+        names.rawDataDecoderAndSanitizer = sUsdaiVaultDecoderAndSanitizerName;
+        names.delayedWithdrawer = sUsdaiVaultDelayedWithdrawer;
 
         configureDeployment.deployContracts = true;
         configureDeployment.setupRoles = true;
@@ -56,7 +56,7 @@ contract DeployTestVaultScript is DeployArcticArchitecture2, KatanaBokutoAddress
 
         // Define Accountant Parameters.
         accountantParameters.payoutAddress = liquidPayoutAddress;
-        accountantParameters.base = USDC;
+        accountantParameters.base = USDAI;
         // Decimals are in terms of `base`.
         accountantParameters.startingExchangeRate = 1e6;
         //  4 decimals
@@ -68,55 +68,23 @@ contract DeployTestVaultScript is DeployArcticArchitecture2, KatanaBokutoAddress
         accountantParameters.minimumUpateDelayInSeconds = 1 days / 4;
 
         // Define Decoder and Sanitizer deployment details.
-        bytes memory creationCode = type(ITBPositionDecoderAndSanitizer).creationCode;
-        // bytes memory constructorArgs = abi.encode(previousVault);
-        bytes memory constructorArgs =
-            abi.encode(deployer.getAddress(names.boringVault));
+        bytes memory creationCode = type(BaseDecoderAndSanitizer).creationCode;
+        bytes memory constructorArgs = abi.encode(deployer.getAddress(names.boringVault));
 
-        // // Setup extra deposit assets.
-        // depositAssets.push(
-        //     DepositAsset({
-        //         asset: USDT,
-        //         isPeggedToBase: false,
-        //         rateProvider: address(0x2A25aF4dFE77b9CB3C426CDa86baa76c16547CE5),
-        //         genericRateProviderName: "USDT",
-        //         target: address(0),
-        //         selector: bytes4(0),
-        //         params: [bytes32(0), bytes32(0), bytes32(0), bytes32(0), bytes32(0), bytes32(0), bytes32(0), bytes32(0)]
-        //     })
-        // );
+        // Setup extra deposit assets.
 
         // Setup withdraw assets.
-        withdrawAssets.push(
-            WithdrawAsset({
-                asset: USDC,
-                withdrawDelay: 3 minutes,
-                completionWindow: 7 days,
-                withdrawFee: 0,
-                maxLoss: 0.01e4
-            })
-        );
-
-        // withdrawAssets.push(
-        //     WithdrawAsset({
-        //         asset: USDT,
-        //         withdrawDelay: 3 minutes,
-        //         completionWindow: 7 days,
-        //         withdrawFee: 0,
-        //         maxLoss: 0.01e4
-        //     })
-        // );
 
         bool allowPublicDeposits = true;
         bool allowPublicWithdraws = true;
-        uint64 shareLockPeriod = 1;
+        uint64 shareLockPeriod = 0;
         address delayedWithdrawFeeAddress = liquidPayoutAddress;
 
         vm.startBroadcast(privateKey);
 
         _deploy(DeployParams({
-            previousBoringVault: address(0),
-            deploymentFileName: "SuperUSDKatanaBokutoDeployment.json",
+            previousBoringVault: previoussuperUSD,
+            deploymentFileName: "sSuperUSDPlumeTestnetDeployment.json",
             owner: owner,
             boringVaultName: boringVaultName,
             boringVaultSymbol: boringVaultSymbol,

--- a/script/sepolia/DeployTestVault.s.sol
+++ b/script/sepolia/DeployTestVault.s.sol
@@ -115,6 +115,7 @@ contract DeployTestVaultScript is DeployArcticArchitecture2, SepoliaAddresses {
         vm.startBroadcast(privateKey);
 
         _deploy(DeployParams({
+            previousBoringVault: address(0),
             deploymentFileName: "SuperUSDSepoliaDeployment.json",
             owner: owner,
             boringVaultName: boringVaultName,

--- a/script/sepolia/DeploysUSDAITestVault.s.sol
+++ b/script/sepolia/DeploysUSDAITestVault.s.sol
@@ -83,6 +83,7 @@ contract DeployTestVaultScript is DeployArcticArchitecture, SepoliaAddresses {
         vm.startBroadcast(privateKey);
 
         _deploy(DeployParams({
+            previousBoringVault: address(0),
             deploymentFileName: "sSuperUSDSepoliaDeployment.json",
             owner: owner,
             boringVaultName: boringVaultName,

--- a/test/redeploy.t.sol
+++ b/test/redeploy.t.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.21;
+
+import {BoringVault} from "src/base/BoringVault.sol";
+import {AccountantWithRateProviders} from "src/base/Roles/AccountantWithRateProviders.sol";
+import {Authority} from "@solmate/auth/Auth.sol";
+import {SafeTransferLib} from "@solmate/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solmate/utils/FixedPointMathLib.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {IRateProvider} from "src/interfaces/IRateProvider.sol";
+import {ILiquidityPool} from "src/interfaces/IStaking.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {AtomicSolverV4} from "src/atomic-queue/AtomicSolverV4.sol";
+import {AtomicQueue, AtomicRequest} from "src/atomic-queue/AtomicQueue.sol";
+import {MerkleTreeHelper} from "test/resources/MerkleTreeHelper/MerkleTreeHelper.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {Test, stdStorage, StdStorage, stdError, console} from "@forge-std/Test.sol";
+import {Deployer} from "src/helper/Deployer.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ContractNames} from "resources/ContractNames.sol";
+import {PlumeTestnetAddresses} from "test/resources/PlumeTestnetAddresses.sol";
+
+/*
+ * This test primarily validates the redeployment process, which consists of two main parts:
+ * 1. Testing the basic operation with the old and new Boring Vault role authority
+ * 2. Upgrading the Boring Vault implementation
+ *
+ * The test ensures that:
+ * a. Previous contracts become unavailable and new contracts become available after updating the Boring Vault role authority
+ * b. New contracts continue to function properly after upgrading the Boring Vault implementation
+ *
+ * Note: All tests are based on actual deployed contracts (not mocks), so deployment scripts must be run first.
+ * The test must be executed before setting the new role authority and performing upgrades.
+ * Remember to update the RPC endpoint, block number, baseAsset, and contract addresses (inherit and hardcode) for each chain before running the test.
+ */
+contract RedeployTest is Test, ContractNames, PlumeTestnetAddresses{
+    using SafeTransferLib for ERC20;
+    using FixedPointMathLib for uint256;
+    using stdStorage for StdStorage;
+
+    BoringVault public boringVault;
+    Deployer public deployer;
+    ERC20 public baseAsset;
+
+    address public user;
+    address public admin;
+
+    address public constant superusd                    = address(0x1C6DfA6C99d83aE8b872C32119575ce24407767C);
+    
+    address public constant oldSuperusdDeployer         = address(0x62165b41138c5841c0a54137E6470FBfEdd18a2e);
+    address public constant oldSuperusdImpl             = address(0xD71A61A52d37DD5B740DA9e19aE5bA6eC1dDD13B);
+    address public constant oldSuperusdRolesAuthority   = address(0x482ff8226a3f213d5fDC053E40ebD14AA213A43b);
+    address public constant oldSuperusdAccountant       = address(0x05e118c77F6DFF4d26f9549A8A479C2049b81e50);
+    address public constant oldSuperusdLens             = address(0xd8b0c6ca82d912a5BcaC8cA299D2c0bc6E2527c1);
+    address public constant oldSuperusdManager          = address(0x26bd7bD8cD42e4B6a6B0805c0526833D2acd5Ec9);
+    address public constant oldSuperusdTeller           = address(0x4252B2aA01C3948562546feFf1c1Ac809645CfD3);
+    address public constant oldSuperusdSolver           = address(0x0ec3599353e592b4Ef69CC3A550d0923b077CAB5);
+    address public constant oldSuperusdQueue            = address(0x2f16484e1760Fa5A3266Ce3A9831ed1B63835753);
+    address public constant oldSuperusdQueueAuthority   = address(0xa566a8Ca5F93cdC1427b28420d4044A97BBd80Bd);
+
+    address public constant newSuperusdDeployer         = address(0x6A0FE0ab71583F23Ea62904cd2C98DD18E0F9096);
+    address public constant newSuperusdRolesAuthority   = address(0x9EcC12a700F4C971d69202b244fEbF30B947ecA5);
+    address public constant newSuperusdAccountant       = address(0x67Bc6036c34d244F0C4dDEDf697FD550C96147Cc);
+    address public constant newSuperusdLens             = address(0x7a935be5Aa25aE8A6961C500A14A078f7101A4E6);
+    address public constant newSuperusdManager          = address(0x9B7063A1a07Fec4e776ea139000239f5fC7Eab80);
+    address public constant newSuperusdTeller           = address(0x7CCd743d49f80dcA1c04667C2D7d0524f1244901);
+    address public constant newSuperusdSolver           = address(0x753684080CdA249f2238016c8DffA30809bb8d4A);
+    address public constant newSuperusdQueue            = address(0x044F86c77c872feA76C5b3D303541967ca976C4A);
+    address public constant newSuperusdQueueAuthority   = address(0x2185Fdd5cE287e4B4F40Cd1deEf3719A4284042a);
+
+    struct basicOperationParams {
+        address teller;
+        address manager;
+        address accountant;
+        address boringVault;
+        address rolesAuthority;
+        address queue;
+        address solver;
+    }
+
+    function setUp() external {
+        // Setup forked environment.
+        string memory rpcKey = "PLUME_RPC_URL";
+        uint256 blockNumber = 22148000;
+        baseAsset = ERC20(PUSD);
+
+        _startFork(rpcKey, blockNumber);
+
+        boringVault = BoringVault(payable(superusd));
+
+        admin = dev0Address;
+        user = vm.addr(100);
+
+        vm.startPrank(admin);
+    }
+
+    function testUpdateBoringVaultRoleAuthority() external {
+        // Check initial state - old authority is set
+        // comment this since the authority is updated when redeploying the contracts in DeployArcticArchitecture "Set all RolesAuthorities." part
+        // assertEq(address(boringVault.authority()), oldSuperusdRolesAuthority);
+        
+        // Set new role authority here
+        // comment this since the authority is updated when redeploying the contracts in DeployArcticArchitecture "Set all RolesAuthorities." part
+        // boringVault.setAuthority(Authority(newSuperusdRolesAuthority));
+        
+        // After switching authority, basic operations work with new contracts
+        vm.stopPrank();
+        vm.startPrank(user);
+        basicOperationAndViewWithNewDeployment(
+            basicOperationParams(
+                newSuperusdTeller,
+                newSuperusdManager,
+                newSuperusdAccountant,
+                superusd,
+                newSuperusdRolesAuthority,
+                newSuperusdQueue,
+                newSuperusdSolver
+            )
+        );
+
+        // should fail since the authority in boring vault is updated
+        basicOperationAndViewWithOldDeployment(
+            basicOperationParams(
+                oldSuperusdTeller,
+                oldSuperusdManager,
+                oldSuperusdAccountant,
+                superusd,
+                oldSuperusdRolesAuthority,
+                oldSuperusdQueue,
+                oldSuperusdSolver
+            )
+        );
+        vm.stopPrank();
+    }
+
+    function testUpgradeImplementation() external {
+        // deploy the new implementation
+        address newImplementation = Deployer(newSuperusdDeployer).deployContract(
+            "Implementation",
+            type(BoringVault).creationCode,
+            hex"",
+            0
+        );
+
+        RolesAuthority(newSuperusdRolesAuthority).setRoleCapability(
+            1,
+            address(boringVault),
+            bytes4(abi.encodeWithSignature("upgradeToAndCall(address,bytes)")),
+            true
+        );
+
+        // upgrade the implementation
+        boringVault.upgradeToAndCall(newImplementation, "");
+
+        // Check that the implementation has been upgraded
+        bytes32 IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        address currentImplementation = address(uint160(uint256(vm.load(address(boringVault), IMPLEMENTATION_SLOT))));
+        assertEq(currentImplementation, newImplementation, "Implementation should be upgraded to newImplementation");
+
+        vm.stopPrank();
+        
+        // the basic operation should work
+        vm.startPrank(user);
+        basicOperationAndViewWithNewDeployment(
+            basicOperationParams(
+                newSuperusdTeller,
+                newSuperusdManager,
+                newSuperusdAccountant,
+                superusd,
+                newSuperusdRolesAuthority,
+                newSuperusdQueue,
+                newSuperusdSolver
+            )
+        );
+        vm.stopPrank();
+    }
+
+    function basicOperationAndViewWithNewDeployment(basicOperationParams memory params) internal{
+        // view
+        // after redeploy and upgrade, the old and new accountant should still work
+        AccountantWithRateProviders accountant = AccountantWithRateProviders(params.accountant);
+        assertNotEq(accountant.getRateSafe(), 0, "Exchange rate should not be 0");
+
+        // 1. deposit
+        TellerWithMultiAssetSupport teller = TellerWithMultiAssetSupport(params.teller);
+        AtomicQueue atomicQueue = AtomicQueue(params.queue);
+        AtomicSolverV4 atomicSolverV4 = AtomicSolverV4(params.solver);
+
+        deal(address(baseAsset), user, 1e6);
+        // assertEq(ERC20(params.boringVault).balanceOf(user), 0);
+        baseAsset.safeApprove(params.boringVault, type(uint256).max);
+
+        teller.deposit(baseAsset, 1e6, 0);
+        assertGt(ERC20(params.boringVault).balanceOf(user), 0);
+
+        // 2. send withdraw queue and solve
+        ERC20(params.boringVault).safeApprove(address(atomicQueue), type(uint256).max);
+        AtomicRequest memory req = AtomicRequest({
+            deadline: uint64(block.timestamp * 2),
+            creationTime: uint64(block.timestamp),
+            offerAmount: uint96(ERC20(params.boringVault).balanceOf(user)),
+            user: user,
+            offer: address(params.boringVault),
+            want: address(baseAsset)
+        });
+
+        atomicQueue.updateAtomicRequest(req);
+
+        vm.warp(block.timestamp * 2 - 1);
+
+        atomicSolverV4.redeemSolve(
+            atomicQueue, 0, type(uint256).max, teller, req
+        );
+    }
+
+    function basicOperationAndViewWithOldDeployment(basicOperationParams memory params) internal{
+        // view
+        // after redeploy and upgrade, the old and new accountant should still work
+        AccountantWithRateProviders accountant = AccountantWithRateProviders(params.accountant);
+        assertNotEq(accountant.getRateSafe(), 0, "Exchange rate should not be 0");
+
+        // // 1. deposit
+        TellerWithMultiAssetSupport teller = TellerWithMultiAssetSupport(params.teller);
+
+        deal(address(baseAsset), user, 1e6);
+        baseAsset.safeApprove(params.boringVault, type(uint256).max);
+
+        // After entering the vault, it will check the authorization using the authority set on the BoringVault,
+        // so the previous teller will revert when executing.
+        vm.expectRevert("UNAUTHORIZED");
+        teller.deposit(baseAsset, 1e6, 0);
+    }
+
+    // ========================================= HELPER FUNCTIONS =========================================
+    function _startFork(string memory rpcKey, uint256 blockNumber) internal returns (uint256 forkId) {
+        forkId = vm.createFork(vm.envString(rpcKey), blockNumber);
+        vm.selectFork(forkId);
+    }
+}

--- a/test/redeploy.t.sol
+++ b/test/redeploy.t.sol
@@ -20,6 +20,33 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 import {ContractNames} from "resources/ContractNames.sol";
 import {PlumeTestnetAddresses} from "test/resources/PlumeTestnetAddresses.sol";
 
+// Add this struct before the interface IBoringOnChainQueue
+struct OnChainWithdraw {
+    uint96 nonce; 
+    address user; 
+    address assetOut; 
+    uint128 amountOfShares;
+    uint128 amountOfAssets;
+    uint40 creationTime;
+    uint24 secondsToMaturity;
+    uint24 secondsToDeadline;
+}
+
+interface IBoringOnChainQueue {
+    function requestOnChainWithdraw(
+        address assetOut,
+        uint128 amountOfShares,
+        uint16 discount,
+        uint24 secondsToDeadline
+    ) external returns (bytes32 requestId);
+
+    function getOnChainWithdraw(bytes32 requestId) external view returns (OnChainWithdraw memory);
+}
+
+interface IBoringSolver {
+    function boringRedeemSelfSolve(OnChainWithdraw calldata request, address teller) external;
+}
+
 /*
  * This test primarily validates the redeployment process, which consists of two main parts:
  * 1. Testing the basic operation with the old and new Boring Vault role authority
@@ -95,13 +122,8 @@ contract RedeployTest is Test, ContractNames, PlumeTestnetAddresses{
     }
 
     function testUpdateBoringVaultRoleAuthority() external {
-        // Check initial state - old authority is set
-        // comment this since the authority is updated when redeploying the contracts in DeployArcticArchitecture "Set all RolesAuthorities." part
-        // assertEq(address(boringVault.authority()), oldSuperusdRolesAuthority);
-        
         // Set new role authority here
-        // comment this since the authority is updated when redeploying the contracts in DeployArcticArchitecture "Set all RolesAuthorities." part
-        // boringVault.setAuthority(Authority(newSuperusdRolesAuthority));
+        boringVault.setAuthority(Authority(newSuperusdRolesAuthority));
         
         // After switching authority, basic operations work with new contracts
         vm.stopPrank();
@@ -219,7 +241,7 @@ contract RedeployTest is Test, ContractNames, PlumeTestnetAddresses{
         AccountantWithRateProviders accountant = AccountantWithRateProviders(params.accountant);
         assertNotEq(accountant.getRateSafe(), 0, "Exchange rate should not be 0");
 
-        // // 1. deposit
+        // 1. deposit
         TellerWithMultiAssetSupport teller = TellerWithMultiAssetSupport(params.teller);
 
         deal(address(baseAsset), user, 1e6);
@@ -229,6 +251,23 @@ contract RedeployTest is Test, ContractNames, PlumeTestnetAddresses{
         // so the previous teller will revert when executing.
         vm.expectRevert("UNAUTHORIZED");
         teller.deposit(baseAsset, 1e6, 0);
+
+        // 2. send withdraw queue and solve
+        deal(address(params.boringVault), user, 1e6);
+        ERC20(params.boringVault).safeApprove(address(params.queue), type(uint256).max);
+        bytes32 requestId = IBoringOnChainQueue(params.queue).requestOnChainWithdraw(
+            address(baseAsset),
+            1 * 1e5,
+            3,
+            10 minutes
+        );
+        OnChainWithdraw memory onChainWithdraw = IBoringOnChainQueue(params.queue).getOnChainWithdraw(requestId);
+
+        vm.warp(block.timestamp + 10 minutes - 1);
+        // After entering the vault, it will check the authorization using the authority set on the BoringVault,
+        // so the previous teller will revert when executing.
+        vm.expectRevert("UNAUTHORIZED");
+        IBoringSolver(params.solver).boringRedeemSelfSolve(onChainWithdraw, params.teller);
     }
 
     // ========================================= HELPER FUNCTIONS =========================================

--- a/test/resources/ChainValues.sol
+++ b/test/resources/ChainValues.sol
@@ -15,6 +15,7 @@ contract ChainValues {
     string public constant arbitrum = "arbitrum";
     string public constant optimism = "optimism";
     string public constant base = "base";
+    string public constant plume = "plume";
 
     string public constant sepolia = "sepolia";
     string public constant katanabokuto = "katanabokuto";
@@ -65,9 +66,11 @@ contract ChainValues {
         _addBaseValues();
         _addArbitrumValues();
         _addOptimismValues();
+        
         // Add testnet values
         _addSepoliaValues();
         _addKatanaBokutoValues();
+        _addPlumeTestnetValues();
     }
 
     function _addMainnetValues() private {
@@ -936,5 +939,11 @@ contract ChainValues {
         values[katanabokuto]["dev0Address"] = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4.toBytes32();
         values[katanabokuto]["dev1Address"] = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4.toBytes32();
         values[katanabokuto]["USDC"] = 0xc2a4C310F2512A17Ac0047cf871aCAed3E62bB4B.toBytes32(); // vdusdc
+    }
+    function _addPlumeTestnetValues() private {
+        values[plume]["deployerAddress"] = 0x6A0FE0ab71583F23Ea62904cd2C98DD18E0F9096.toBytes32();
+        values[plume]["dev0Address"] = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4.toBytes32();
+        values[plume]["dev1Address"] = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4.toBytes32();
+        values[plume]["PUSD"] = 0x78adD880A697070c1e765Ac44D65323a0DcCE913.toBytes32();
     }
 }

--- a/test/resources/PlumeTestnetAddresses.sol
+++ b/test/resources/PlumeTestnetAddresses.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.21;
+
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
+contract PlumeTestnetAddresses {
+    // Liquid Ecosystem
+    address public deployerAddress = 0x6A0FE0ab71583F23Ea62904cd2C98DD18E0F9096;
+    address public dev0Address = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+    address public dev1Address = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+    address public previoussuperUSD = 0x1C6DfA6C99d83aE8b872C32119575ce24407767C;
+    address public previoussSuperUSD = 0xE47B7cA2C2c8fDbB29A38d63804A795E8F899616;
+    // address public liquidV1PriceRouter = 0x693799805B502264f9365440B93C113D86a4fFF5;
+    // should be a multisig address!
+    address public liquidPayoutAddress = 0x8Ab8aEEf444AeE718A275a8325795FE90CF162c4;
+
+    // CCIP token transfers.
+    address public ccipRouter = 0x5e5Fd4720E1CE826138D043aF578D69f48af502F;
+
+    // should be update
+    // address public uniswapV3NonFungiblePositionManager = 0x655C406EBFa14EE2006250925e54ec43AD184f8B;
+
+    ERC20 public PUSD = ERC20(0x1E0E030AbCb4f07de629DCCEa458a271e0E82624);
+    ERC20 public USDC = ERC20(0x78adD880A697070c1e765Ac44D65323a0DcCE913);
+    ERC20 public USDAI = ERC20(0x15f3Ee2F609FBAe0bC48E3a071D66DD917C682EB);
+
+    address public WPLUME = 0xEa237441c92CAe6FC17Caaf9a7acB3f953be4bd1;
+}


### PR DESCRIPTION
For the redeployment, we redeploy everything except the BoringVault proxy. We redeploy the RoleAuthority as well.
There is no new redeployment script. We can directly run the same script like what we did to deploy a whole new "set".
(Set here means all the contracts we are using, including accountant, teller, queue...)
The difference between redeploying a new set without the BoringVault and deploying a whole new set is in DeployTestVaultScript.
If you want to redeploy a new set without the BoringVault, place previousBoringVault in the script.
https://github.com/SuperReturn/superreturn-superUSD/blob/redeployment/script/plumeTestnet/DeployTestVault.s.sol#L118
If you want to deploy a whole new set, place address(0) in the script.
https://github.com/SuperReturn/superreturn-superUSD/blob/redeployment/script/sepolia/DeployTestVault.s.sol#L118
In DeployArcticArchitecture, it will check whether previousBoringVault is address(0) to determine whether it needs to deploy a new BoringVault.
https://github.com/SuperReturn/superreturn-superUSD/blob/redeployment/script/ArchitectureDeployments/DeployArcticArchitecture.sol#L173-L213
Also, in the DeployArcticArchitecture _deploy process, it will directly update the RoleAuthority in the BoringVault as well, so we don't need to update manually.
https://github.com/SuperReturn/superreturn-superUSD/blob/redeployment/script/ArchitectureDeployments/DeployArcticArchitecture.sol#L895

In the [test file](https://github.com/SuperReturn/superreturn-superUSD/blob/redeployment/test/redeploy.t.sol) , for now I have simply tested the old set operations where the vault should revert, and the new set should work.
I tested the implementation upgrade as well.
I can write more tests in this file if you think all the concepts and progress make sense.

I didn't push the ContractName.sol that I used to deploy the Plume testnet set. Let me know if you want me to push it.